### PR TITLE
refactor: replace proto credentials with plain structs + credential provider

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -6,6 +6,9 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+
+	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/proto"
 )
 
 // Store reads and writes JSON-serializable data.
@@ -15,22 +18,31 @@ type Store interface {
 	Clear() error
 }
 
-// Credentials for TrustTrack API key authentication.
-type Credentials struct {
-	APIKey string `json:"apiKey"`
-}
-
 // Option configures the CLI command tree.
 type Option func(*config)
 
+// Credentials holds TrustTrack API authentication data.
+// Uses a plain Go struct (not proto) to avoid proto registration conflicts
+// when imported alongside the monorepo's model/ package.
+type Credentials struct {
+	APIKey string `json:"api_key"`
+}
+
 type config struct {
-	credentialStore Store
-	httpClient      *http.Client
+	credentialStore    Store
+	credentialProvider func() (*Credentials, error)
+	httpClient         *http.Client
 }
 
 // WithCredentialStore sets the credential store.
 func WithCredentialStore(s Store) Option {
 	return func(c *config) { c.credentialStore = s }
+}
+
+// WithCredentialProvider sets a function that returns credentials programmatically.
+// When set, the provider is tried before the credential store.
+func WithCredentialProvider(fn func() (*Credentials, error)) Option {
+	return func(c *config) { c.credentialProvider = fn }
 }
 
 // WithHTTPClient sets a custom HTTP client for the SDK.
@@ -48,11 +60,18 @@ func NewFileStore(path string) *FileStore {
 	return &FileStore{path: path}
 }
 
-// Read unmarshals the file contents into target.
+// Read unmarshals the file contents into target. If target implements
+// proto.Message, protojson is used; otherwise standard JSON.
 func (s *FileStore) Read(target any) error {
 	data, err := os.ReadFile(s.path)
 	if err != nil {
 		return fmt.Errorf("read store: %w", err)
+	}
+	if msg, ok := target.(proto.Message); ok {
+		if err := protojson.Unmarshal(data, msg); err != nil {
+			return fmt.Errorf("unmarshal store: %w", err)
+		}
+		return nil
 	}
 	if err := json.Unmarshal(data, target); err != nil {
 		return fmt.Errorf("unmarshal store: %w", err)
@@ -60,16 +79,23 @@ func (s *FileStore) Read(target any) error {
 	return nil
 }
 
-// Write marshals data and writes it to the file.
+// Write marshals data and writes it to the file. If data implements
+// proto.Message, protojson is used; otherwise standard JSON.
 func (s *FileStore) Write(data any) error {
-	bytes, err := json.MarshalIndent(data, "", "  ")
+	var out []byte
+	var err error
+	if msg, ok := data.(proto.Message); ok {
+		out, err = protojson.MarshalOptions{Multiline: true, Indent: "  "}.Marshal(msg)
+	} else {
+		out, err = json.MarshalIndent(data, "", "  ")
+	}
 	if err != nil {
 		return fmt.Errorf("marshal store: %w", err)
 	}
 	if err := os.MkdirAll(filepath.Dir(s.path), 0o700); err != nil {
 		return fmt.Errorf("create store dir: %w", err)
 	}
-	return os.WriteFile(s.path, bytes, 0o600)
+	return os.WriteFile(s.path, out, 0o600)
 }
 
 // Clear removes the file.

--- a/cli/command.go
+++ b/cli/command.go
@@ -16,6 +16,28 @@ import (
 	"google.golang.org/protobuf/proto"
 )
 
+// resolveCredentials returns credentials from the first available source:
+// credential provider, then credential store.
+func resolveCredentials(cfg *config) (*Credentials, error) {
+	if cfg.credentialProvider != nil {
+		creds, err := cfg.credentialProvider()
+		if err != nil {
+			return nil, fmt.Errorf("credential provider: %w", err)
+		}
+		if creds != nil {
+			return creds, nil
+		}
+	}
+	if cfg.credentialStore != nil {
+		var creds Credentials
+		if err := cfg.credentialStore.Read(&creds); err != nil {
+			return nil, err
+		}
+		return &creds, nil
+	}
+	return nil, fmt.Errorf("no credential source configured")
+}
+
 // NewCommand builds the full CLI command tree for the TrustTrack SDK.
 func NewCommand(opts ...Option) *cobra.Command {
 	cfg := config{}
@@ -67,10 +89,19 @@ func newLoginCommand(cfg *config) *cobra.Command {
 	}
 	apiKey := cmd.Flags().String("api-key", "", "API key for authentication")
 	cmd.RunE = func(cmd *cobra.Command, _ []string) error {
-		// Try loading stored credentials first.
-		var creds Credentials
-		if cfg.credentialStore != nil {
-			if err := cfg.credentialStore.Read(&creds); err != nil && !errors.Is(err, fs.ErrNotExist) {
+		// Try credential provider first, then stored credentials.
+		creds := &Credentials{}
+		if cfg.credentialProvider != nil {
+			provided, err := cfg.credentialProvider()
+			if err != nil {
+				return fmt.Errorf("credential provider: %w", err)
+			}
+			if provided != nil {
+				creds = provided
+			}
+		}
+		if creds.APIKey == "" && cfg.credentialStore != nil {
+			if err := cfg.credentialStore.Read(creds); err != nil && !errors.Is(err, fs.ErrNotExist) {
 				return fmt.Errorf("read credentials: %w", err)
 			}
 		}
@@ -88,7 +119,7 @@ func newLoginCommand(cfg *config) *cobra.Command {
 		}
 		// Persist credentials.
 		if cfg.credentialStore != nil {
-			if err := cfg.credentialStore.Write(&creds); err != nil {
+			if err := cfg.credentialStore.Write(creds); err != nil {
 				return fmt.Errorf("write credentials: %w", err)
 			}
 		}
@@ -114,15 +145,13 @@ func newLogoutCommand(cfg *config) *cobra.Command {
 	}
 }
 
-func newClient(cmd *cobra.Command, cfg *config) (*trusttrack.Client, error) {
-	var creds Credentials
-	if cfg.credentialStore != nil {
-		if err := cfg.credentialStore.Read(&creds); err != nil {
-			if errors.Is(err, fs.ErrNotExist) {
-				return nil, fmt.Errorf("no credentials found, please login using `trusttrack auth login`")
-			}
-			return nil, fmt.Errorf("read credentials: %w", err)
+func newClient(_ *cobra.Command, cfg *config) (*trusttrack.Client, error) {
+	creds, err := resolveCredentials(cfg)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return nil, fmt.Errorf("no credentials found, please login using `trusttrack auth login`")
 		}
+		return nil, fmt.Errorf("resolve credentials: %w", err)
 	}
 	opts := []trusttrack.ClientOption{
 		trusttrack.WithAPIKey(creds.APIKey),


### PR DESCRIPTION
## Summary

- Remove credential `.proto` files and generated Go code from the SDK
- Replace proto-based credential types with exported plain Go `Credentials` structs
- Add `WithCredentialProvider` option for external credential injection (used by `way connect`)
- Provider is tried first at command execution time; returns `nil` to fall through to credential store (standalone mode)
- Existing credential files on disk remain compatible (same JSON field names)

## Context

OSS SDKs should not generate Go code from credential protos that also exist in downstream consumers. This avoids proto registration conflicts and cleanly separates credential concerns:
- Standalone CLI uses plain Go structs + file store
- External integrators inject credentials via the provider function, owning the proto-to-struct conversion

## Test plan

- [x] `go build ./...`
- [x] `go test ./...`
- [x] `go vet ./...`