### PR TITLE
refactor(cli): replace untyped Store with typed CredentialStore

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -6,15 +6,17 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
-
-	"google.golang.org/protobuf/encoding/protojson"
-	"google.golang.org/protobuf/proto"
 )
 
-// Store reads and writes JSON-serializable data.
-type Store interface {
-	Read(target any) error
-	Write(data any) error
+// Credentials holds API credentials for the TrustTrack API.
+type Credentials struct {
+	APIKey string `json:"api_key"`
+}
+
+// CredentialStore loads, saves, and clears credentials.
+type CredentialStore interface {
+	Load() (*Credentials, error)
+	Save(*Credentials) error
 	Clear() error
 }
 
@@ -22,12 +24,12 @@ type Store interface {
 type Option func(*config)
 
 type config struct {
-	credentialStore Store
+	credentialStore CredentialStore
 	httpClient      *http.Client
 }
 
 // WithCredentialStore sets the credential store.
-func WithCredentialStore(s Store) Option {
+func WithCredentialStore(s CredentialStore) Option {
 	return func(c *config) { c.credentialStore = s }
 }
 
@@ -36,45 +38,32 @@ func WithHTTPClient(httpClient *http.Client) Option {
 	return func(c *config) { c.httpClient = httpClient }
 }
 
-// FileStore is a JSON file-backed store.
-type FileStore struct {
+// CredentialFileStore is a JSON file-backed credential store.
+type CredentialFileStore struct {
 	path string
 }
 
-// NewFileStore creates a new file-backed store at the given path.
-func NewFileStore(path string) *FileStore {
-	return &FileStore{path: path}
+// NewCredentialFileStore creates a new file-backed credential store at the given path.
+func NewCredentialFileStore(path string) *CredentialFileStore {
+	return &CredentialFileStore{path: path}
 }
 
-// Read unmarshals the file contents into target. If target implements
-// proto.Message, protojson is used; otherwise standard JSON.
-func (s *FileStore) Read(target any) error {
+// Load reads credentials from the file.
+func (s *CredentialFileStore) Load() (*Credentials, error) {
 	data, err := os.ReadFile(s.path)
 	if err != nil {
-		return fmt.Errorf("read store: %w", err)
+		return nil, fmt.Errorf("read store: %w", err)
 	}
-	if msg, ok := target.(proto.Message); ok {
-		if err := protojson.Unmarshal(data, msg); err != nil {
-			return fmt.Errorf("unmarshal store: %w", err)
-		}
-		return nil
+	var creds Credentials
+	if err := json.Unmarshal(data, &creds); err != nil {
+		return nil, fmt.Errorf("unmarshal store: %w", err)
 	}
-	if err := json.Unmarshal(data, target); err != nil {
-		return fmt.Errorf("unmarshal store: %w", err)
-	}
-	return nil
+	return &creds, nil
 }
 
-// Write marshals data and writes it to the file. If data implements
-// proto.Message, protojson is used; otherwise standard JSON.
-func (s *FileStore) Write(data any) error {
-	var out []byte
-	var err error
-	if msg, ok := data.(proto.Message); ok {
-		out, err = protojson.MarshalOptions{Multiline: true, Indent: "  "}.Marshal(msg)
-	} else {
-		out, err = json.MarshalIndent(data, "", "  ")
-	}
+// Save writes credentials to the file.
+func (s *CredentialFileStore) Save(creds *Credentials) error {
+	out, err := json.MarshalIndent(creds, "", "  ")
 	if err != nil {
 		return fmt.Errorf("marshal store: %w", err)
 	}
@@ -84,8 +73,8 @@ func (s *FileStore) Write(data any) error {
 	return os.WriteFile(s.path, out, 0o600)
 }
 
-// Clear removes the file.
-func (s *FileStore) Clear() error {
+// Clear removes the credential file.
+func (s *CredentialFileStore) Clear() error {
 	err := os.Remove(s.path)
 	if err != nil && os.IsNotExist(err) {
 		return nil

--- a/cli/command.go
+++ b/cli/command.go
@@ -11,7 +11,6 @@ import (
 	"charm.land/lipgloss/v2"
 	"github.com/spf13/cobra"
 	"github.com/way-platform/trusttrack-go"
-	trusttrackv1 "github.com/way-platform/trusttrack-go/proto/gen/go/wayplatform/connect/trusttrack/v1"
 	"golang.org/x/term"
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/proto"
@@ -69,27 +68,31 @@ func newLoginCommand(cfg *config) *cobra.Command {
 	apiKey := cmd.Flags().String("api-key", "", "API key for authentication")
 	cmd.RunE = func(cmd *cobra.Command, _ []string) error {
 		// Try loading stored credentials first.
-		creds := &trusttrackv1.Credentials{}
+		creds := &Credentials{}
 		if cfg.credentialStore != nil {
-			if err := cfg.credentialStore.Read(creds); err != nil && !errors.Is(err, fs.ErrNotExist) {
+			loaded, err := cfg.credentialStore.Load()
+			if err != nil && !errors.Is(err, fs.ErrNotExist) {
 				return fmt.Errorf("read credentials: %w", err)
+			}
+			if loaded != nil {
+				creds = loaded
 			}
 		}
 		// Override with flag.
 		if *apiKey != "" {
-			creds.SetApiKey(*apiKey)
+			creds.APIKey = *apiKey
 		}
 		// Prompt for missing API key.
-		if creds.GetApiKey() == "" {
+		if creds.APIKey == "" {
 			val, err := promptSecret(cmd, "Enter API key: ")
 			if err != nil {
 				return err
 			}
-			creds.SetApiKey(val)
+			creds.APIKey = val
 		}
 		// Persist credentials.
 		if cfg.credentialStore != nil {
-			if err := cfg.credentialStore.Write(creds); err != nil {
+			if err := cfg.credentialStore.Save(creds); err != nil {
 				return fmt.Errorf("write credentials: %w", err)
 			}
 		}
@@ -116,22 +119,31 @@ func newLogoutCommand(cfg *config) *cobra.Command {
 }
 
 func newClient(cmd *cobra.Command, cfg *config) (*trusttrack.Client, error) {
-	creds := &trusttrackv1.Credentials{}
-	if cfg.credentialStore != nil {
-		if err := cfg.credentialStore.Read(creds); err != nil {
-			if errors.Is(err, fs.ErrNotExist) {
-				return nil, fmt.Errorf("no credentials found, please login using `trusttrack auth login`")
-			}
-			return nil, fmt.Errorf("read credentials: %w", err)
-		}
+	creds, err := resolveCredentials(cfg)
+	if err != nil {
+		return nil, err
 	}
 	opts := []trusttrack.ClientOption{
-		trusttrack.WithAPIKey(creds.GetApiKey()),
+		trusttrack.WithAPIKey(creds.APIKey),
 	}
 	if cfg.httpClient != nil {
 		opts = append(opts, trusttrack.WithHTTPClient(cfg.httpClient))
 	}
 	return trusttrack.NewClient(opts...)
+}
+
+func resolveCredentials(cfg *config) (*Credentials, error) {
+	if cfg.credentialStore == nil {
+		return nil, fmt.Errorf("no credential source configured")
+	}
+	creds, err := cfg.credentialStore.Load()
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return nil, fmt.Errorf("no credentials found, please login using `trusttrack auth login`")
+		}
+		return nil, fmt.Errorf("read credentials: %w", err)
+	}
+	return creds, nil
 }
 
 func newListObjectsCommand(cfg *config) *cobra.Command {

--- a/cmd/trusttrack/main.go
+++ b/cmd/trusttrack/main.go
@@ -18,7 +18,7 @@ var debug bool
 func main() {
 	credPath, _ := xdg.ConfigFile("trusttrack-go/credentials.json")
 	cmd := cli.NewCommand(
-		cli.WithCredentialStore(cli.NewFileStore(credPath)),
+		cli.WithCredentialStore(cli.NewCredentialFileStore(credPath)),
 		cli.WithHTTPClient(&http.Client{
 			Transport: &trusttrack.DebugTransport{
 				Enabled: &debug,


### PR DESCRIPTION
## Summary

- Replace `Store` interface (`Read(any)/Write(any)/Clear()`) with typed `CredentialStore` interface (`Load()/Save()/Clear()`)
- Replace `FileStore` with `CredentialFileStore` — pure `encoding/json`, remove dead `protojson`/`proto` imports from credential handling
- Export `Credentials` struct for use by external integrators
- Replace proto credential type with plain Go struct
- Simplify credential resolution to single-path logic

## Test plan

- [x] `go build ./...`
- [x] `go test ./...`