### PR TITLE
chore: add BufPush mage target

### DIFF
--- a/tools/magefile.go
+++ b/tools/magefile.go
@@ -72,6 +72,11 @@ func CLI() error {
 	return cmd(root("cmd/trusttrack"), "go", "install", ".").Run()
 }
 
+// BufPush pushes the proto module to the Buf Schema Registry.
+func BufPush() error {
+	return tool(root("proto"), "buf", "push").Run()
+}
+
 // VHS records the CLI GIF using VHS.
 func VHS() error {
 	mg.Deps(CLI)


### PR DESCRIPTION
## Summary

- Adds `BufPush` mage target to `tools/magefile.go`
- Runs `buf push` from the `proto/` directory to publish the proto module to the Buf Schema Registry (`buf.build/way-platform/trusttrack`)
- Prerequisite for including OSS SDK schemas in the monorepo CLI's descriptor set

## Test plan

```bash
cd tools && mage BufPush
```