### PR TITLE
fix(proto): add debug_redact to driver and address PII fields

### DIFF
--- a/proto/gen/go/wayplatform/connect/trusttrack/v1/address.pb.go
+++ b/proto/gen/go/wayplatform/connect/trusttrack/v1/address.pb.go
@@ -342,16 +342,16 @@ var File_wayplatform_connect_trusttrack_v1_address_proto protoreflect.FileDescri
 
 const file_wayplatform_connect_trusttrack_v1_address_proto_rawDesc = "" +
 	"\n" +
-	"/wayplatform/connect/trusttrack/v1/address.proto\x12!wayplatform.connect.trusttrack.v1\"\xdf\x01\n" +
+	"/wayplatform/connect/trusttrack/v1/address.proto\x12!wayplatform.connect.trusttrack.v1\"\xee\x01\n" +
 	"\aAddress\x12\x18\n" +
 	"\acountry\x18\x01 \x01(\tR\acountry\x12!\n" +
 	"\fcountry_code\x18\x02 \x01(\tR\vcountryCode\x12\x16\n" +
-	"\x06county\x18\x03 \x01(\tR\x06county\x12!\n" +
-	"\fhouse_number\x18\x04 \x01(\tR\vhouseNumber\x12\x1a\n" +
+	"\x06county\x18\x03 \x01(\tR\x06county\x12&\n" +
+	"\fhouse_number\x18\x04 \x01(\tB\x03\x80\x01\x01R\vhouseNumber\x12\x1a\n" +
 	"\blocality\x18\x05 \x01(\tR\blocality\x12\x16\n" +
-	"\x06region\x18\x06 \x01(\tR\x06region\x12\x16\n" +
-	"\x06street\x18\a \x01(\tR\x06street\x12\x10\n" +
-	"\x03zip\x18\b \x01(\tR\x03zipB\xbf\x02\n" +
+	"\x06region\x18\x06 \x01(\tR\x06region\x12\x1b\n" +
+	"\x06street\x18\a \x01(\tB\x03\x80\x01\x01R\x06street\x12\x15\n" +
+	"\x03zip\x18\b \x01(\tB\x03\x80\x01\x01R\x03zipB\xbf\x02\n" +
 	"%com.wayplatform.connect.trusttrack.v1B\fAddressProtoP\x01Zagithub.com/way-platform/trusttrack-go/proto/gen/go/wayplatform/connect/trusttrack/v1;trusttrackv1\xa2\x02\x03WCT\xaa\x02!Wayplatform.Connect.Trusttrack.V1\xca\x02!Wayplatform\\Connect\\Trusttrack\\V1\xe2\x02-Wayplatform\\Connect\\Trusttrack\\V1\\GPBMetadata\xea\x02$Wayplatform::Connect::Trusttrack::V1b\beditionsp\xe8\a"
 
 var file_wayplatform_connect_trusttrack_v1_address_proto_msgTypes = make([]protoimpl.MessageInfo, 1)

--- a/proto/gen/go/wayplatform/connect/trusttrack/v1/driver.pb.go
+++ b/proto/gen/go/wayplatform/connect/trusttrack/v1/driver.pb.go
@@ -466,18 +466,18 @@ var File_wayplatform_connect_trusttrack_v1_driver_proto protoreflect.FileDescrip
 
 const file_wayplatform_connect_trusttrack_v1_driver_proto_rawDesc = "" +
 	"\n" +
-	".wayplatform/connect/trusttrack/v1/driver.proto\x12!wayplatform.connect.trusttrack.v1\x1a\x1bbuf/validate/validate.proto\"\xe3\x01\n" +
+	".wayplatform/connect/trusttrack/v1/driver.proto\x12!wayplatform.connect.trusttrack.v1\x1a\x1bbuf/validate/validate.proto\"\xf7\x01\n" +
 	"\x06Driver\x12\x16\n" +
-	"\x02id\x18\x01 \x01(\tB\x06\xbaH\x03\xc8\x01\x01R\x02id\x12\x1d\n" +
+	"\x02id\x18\x01 \x01(\tB\x06\xbaH\x03\xc8\x01\x01R\x02id\x12\"\n" +
 	"\n" +
-	"first_name\x18\x02 \x01(\tR\tfirstName\x12\x1b\n" +
-	"\tlast_name\x18\x03 \x01(\tR\blastName\x12\x18\n" +
-	"\aaddress\x18\x04 \x01(\tR\aaddress\x12\x14\n" +
-	"\x05phone\x18\x05 \x01(\tR\x05phone\x12U\n" +
-	"\videntifiers\x18\x06 \x03(\v23.wayplatform.connect.trusttrack.v1.DriverIdentifierR\videntifiers\"\xc7\x02\n" +
-	"\x10DriverIdentifier\x12\x1e\n" +
+	"first_name\x18\x02 \x01(\tB\x03\x80\x01\x01R\tfirstName\x12 \n" +
+	"\tlast_name\x18\x03 \x01(\tB\x03\x80\x01\x01R\blastName\x12\x1d\n" +
+	"\aaddress\x18\x04 \x01(\tB\x03\x80\x01\x01R\aaddress\x12\x19\n" +
+	"\x05phone\x18\x05 \x01(\tB\x03\x80\x01\x01R\x05phone\x12U\n" +
+	"\videntifiers\x18\x06 \x03(\v23.wayplatform.connect.trusttrack.v1.DriverIdentifierR\videntifiers\"\xcc\x02\n" +
+	"\x10DriverIdentifier\x12#\n" +
 	"\n" +
-	"identifier\x18\x01 \x01(\tR\n" +
+	"identifier\x18\x01 \x01(\tB\x03\x80\x01\x01R\n" +
 	"identifier\x12V\n" +
 	"\x04type\x18\x02 \x01(\x0e2B.wayplatform.connect.trusttrack.v1.DriverIdentifier.IdentifierTypeR\x04type\x126\n" +
 	"\x17unknown_identifier_type\x18\x03 \x01(\tR\x15unknownIdentifierType\"\x82\x01\n" +

--- a/proto/wayplatform/connect/trusttrack/v1/address.proto
+++ b/proto/wayplatform/connect/trusttrack/v1/address.proto
@@ -14,7 +14,7 @@ message Address {
   string county = 3;
 
   // The house number.
-  string house_number = 4;
+  string house_number = 4 [debug_redact = true];
 
   // The locality name.
   string locality = 5;
@@ -23,8 +23,8 @@ message Address {
   string region = 6;
 
   // The street name.
-  string street = 7;
+  string street = 7 [debug_redact = true];
 
   // The ZIP/postal code.
-  string zip = 8;
+  string zip = 8 [debug_redact = true];
 }

--- a/proto/wayplatform/connect/trusttrack/v1/driver.proto
+++ b/proto/wayplatform/connect/trusttrack/v1/driver.proto
@@ -10,16 +10,16 @@ message Driver {
   string id = 1 [(buf.validate.field).required = true];
 
   // The first name of the driver.
-  string first_name = 2;
+  string first_name = 2 [debug_redact = true];
 
   // The last name of the driver.
-  string last_name = 3;
+  string last_name = 3 [debug_redact = true];
 
   // The address of the driver.
-  string address = 4;
+  string address = 4 [debug_redact = true];
 
   // The phone number of the driver.
-  string phone = 5;
+  string phone = 5 [debug_redact = true];
 
   // The identifiers for the driver.
   repeated DriverIdentifier identifiers = 6;
@@ -28,7 +28,7 @@ message Driver {
 // A driver identifier.
 message DriverIdentifier {
   // The identifier code.
-  string identifier = 1;
+  string identifier = 1 [debug_redact = true];
 
   // The type of identifier.
   IdentifierType type = 2;


### PR DESCRIPTION
## Summary

- Add `debug_redact = true` to driver PII: `first_name`, `last_name`, `address`, `phone`, `identifier`
- Add `debug_redact = true` to address fields: `house_number`, `street`, `zip`

## Context

Prevents personal data from appearing in proto debug/text format output (logs, traces). Aligns with the `debug_redact` rollout across the Way Platform monorepo (way-platform/main#4301).

## Test plan

- [x] `mise run build` passes locally
- [ ] CI green